### PR TITLE
fix: rangePicker 선택일 선택 후 닫으면, 이전일로 회귀

### DIFF
--- a/.changeset/rich-lions-sit.md
+++ b/.changeset/rich-lions-sit.md
@@ -1,0 +1,5 @@
+---
+'@musma/react-component': patch
+---
+
+fix: rangePicker 선택일 선택 후 닫으면, 이전일로 회귀


### PR DESCRIPTION
## Fix
1. defaultValue로 날짜가 선택되어있을 때,
시작일만 선택하고 캘린더를 닫으면, defaultValue의 날짜로 onChange 이벤트 실행
2. 종료일의 색이 main 컬러가 아닌 문제